### PR TITLE
Refactored the wrench code, see description.

### DIFF
--- a/gamemodes/mingedefense/entities/weapons/md_wrench/shared.lua
+++ b/gamemodes/mingedefense/entities/weapons/md_wrench/shared.lua
@@ -8,67 +8,115 @@ SWEP.ViewModel = "models/minge_defense/weapons/c_wrench/c_wrench.mdl"
 SWEP.Weight = 2
 SWEP.WorldModel = "models/weapons/w_models/w_wrench.mdl"
 
+local md_wrench_debug = CreateConVar("md_wrench_debug", "0", {FCVAR_DONTRECORD, FCVAR_REPLICATED, FCVAR_CHEAT}, "development", 0, 1)
+
 SWEP.Primary = {
-	Ammo = "none",
-	Automatic = true,
-	ClipSize = -1,
-	DefaultClip = -1
+    Ammo = "none",
+    Automatic = true,
+    ClipSize = -1,
+    DefaultClip = -1
 }
 
 SWEP.Secondary = {
-	Ammo = "none",
-	Automatic = false,
-	ClipSize = -1,
-	DefaultClip = -1
+    Ammo = "none",
+    Automatic = false,
+    ClipSize = -1,
+    DefaultClip = -1
 }
 
-function SWEP:PrimaryAttack()
-	local act
-	local cur_time = CurTime()
-	local owner = self:GetOwner()
-	local trace = owner:GetEyeTrace()
-	
-	if trace.HitPos:Distance(owner:GetShootPos()) <= 75 then
-		act = ACT_VM_HITCENTER
-		local entity = trace.Entity
-		
-		owner:FireBullets({
-				Num =	1,
-				Src =	self.Owner:GetShootPos(),
-				Dir =	self.Owner:GetAimVector(),
-				Spread =	Vector(0, 0, 0),
-				Tracer =	0,
-				Force =		5,
-				Damage =	25
-		})
-		
-		if IsValid(entity) then
-			--random might not be a good idea
-			if entity.IsMinge then self:EmitSound("minge_defense/weapons/wrench/hit_flesh_" .. math.random(4) .. ".wav")
-			else self:EmitSound("minge_defense/weapons/wrench/hit_fail.wav") end
-		else self:EmitSound("minge_defense/weapons/wrench/hit_world.wav") end
-	else
-		act = ACT_VM_MISSCENTER
-		
-		owner:SetAnimation(PLAYER_ATTACK1)
-		self:EmitSound("minge_defense/weapons/wrench/swing.wav")
-	end
-	
-	self:SendWeaponAnim(act)
-	self:SetNextPrimaryFire(cur_time + 0.8)
-	
-	self.NextIdleTime = CurTime() + self:SequenceDuration(self:SelectWeightedSequence(act))
+function SWEP:SetupDataTables()
+    self:NetworkVar("Float", 0, "NextIdleTime")
 end
 
-function SWEP:Reload() end
-function SWEP:SecondaryAttack() end
+function SWEP:PrimaryAttack()
+    local owner = self:GetOwner()
+    local shootpos = owner:GetShootPos()
+    local aimvector = owner:GetAimVector()
+    local activity = ACT_VM_MISSCENTER
+    local tracedata = {}
+    tracedata.start = shootpos
+    tracedata.endpos = shootpos + aimvector * 72
+    tracedata.mins = Vector(-6, -6, -6)
+    tracedata.maxs = Vector(6, 6, 6)
+    tracedata.mask = MASK_SHOT_HULL
+    tracedata.filter = owner
+    owner:LagCompensation(true)
+    local trace = util.TraceHull(tracedata)
 
-function SWEP:SharedInitialize() self:SetHoldType("melee") end
+    if IsFirstTimePredicted() and md_wrench_debug:GetBool() then
+        local angle = (tracedata.endpos - tracedata.start):Angle()
+        local color = Either(SERVER, Color(0, 0, 255, 25), Color(255, 0, 0, 25)) -- equivalent of C++'s condition ? truevar : falsevar
+        local mins = tracedata.mins
+        local maxs = tracedata.maxs + Vector((tracedata.endpos - tracedata.start):Length(), 0, 0)
+        debugoverlay.BoxAngles(tracedata.start, mins, maxs, angle, 4, Color(0, 255, 0, 25))
+        debugoverlay.BoxAngles(trace.HitPos, tracedata.mins, tracedata.maxs, trace.Normal:Angle(), 4, color)
+
+        if IsValid(trace.Entity) then
+            debugoverlay.BoxAngles(trace.Entity:GetPos(), trace.Entity:OBBMins(), trace.Entity:OBBMaxs(), trace.Entity:GetAngles(), 4, color)
+        end
+    end
+
+    if trace.Hit then
+        activity = ACT_VM_HITCENTER
+        local sndeffect = "minge_defense/weapons/wrench/hit_world.wav"
+
+        --[[|| util.GetSurfaceInfo(trace.SurfaceProps.Name).Surface == SURF_HITBOX]]
+        if (trace.MatType == MAT_FLESH) then
+            -- play a different sound when we hit flesh.
+            sndeffect = "minge_defense/weapons/wrench/hit_flesh_" .. math.random(4) .. ".wav"
+        end
+
+        local hitentity = trace.Entity
+
+        if IsValid(hitentity) and SERVER then
+            local dmginfo = DamageInfo()
+            dmginfo:SetInflictor(self)
+            dmginfo:SetAttacker(owner)
+            dmginfo:SetDamage(25)
+            dmginfo:SetDamageType(DMG_CLUB)
+            dmginfo:SetDamagePosition(trace.HitPos)
+            dmginfo:SetDamageForce(trace.Normal * 5000) -- God knows how many newtons this is
+            hitentity:TakeDamageInfo(dmginfo)
+        end
+
+        -- Fake the impact effect
+        local impacttrace = util.TraceLine(tracedata)
+
+        if impacttrace.Hit then
+            owner:FireBullets({
+                Src = trace.StartPos,
+                Dir = trace.Normal,
+                Tracer = 0,
+                Force = 0,
+                Damage = 0
+            })
+        end
+
+        self:EmitSound(sndeffect)
+    else
+        self:EmitSound("minge_defense/weapons/wrench/swing.wav")
+    end
+
+    self:SendWeaponAnim(activity)
+    self:SetNextPrimaryFire(CurTime() + 0.8)
+    self:SetNextIdleTime(CurTime() + self:SequenceDuration(self:SelectWeightedSequence(activity)))
+    owner:SetAnimation(PLAYER_ATTACK1)
+    owner:LagCompensation(false)
+end
+
+function SWEP:Reload()
+end
+
+function SWEP:SecondaryAttack()
+end
+
+function SWEP:SharedInitialize()
+    self:SetHoldType("melee")
+end
 
 function SWEP:Think()
-	if self.NextIdleTime and CurTime() > self.NextIdleTime then
-		self.NextIdleTime = nil
-		
-		self:SendWeaponAnim(ACT_VM_IDLE)
-	end
+    if self:GetNextIdleTime() ~= 0 and CurTime() > self:GetNextIdleTime() then
+        self:SetNextIdleTime(0)
+        self:SendWeaponAnim(ACT_VM_IDLE)
+    end
 end


### PR DESCRIPTION
[GAME]
+ Added proper lag compensation
+ Fixed prediction error caused by weapon idle time (001 CBaseCombatWeapon::m_flTimeWeaponIdle - float differs (net 2613.458252 pred 2613.473389) diff(0.015137))
+ Added debug command that has no actual use now because it was only used during development to visualize the hull trace cast by the attack.
+ Sound effects now properly switch between hitworld and hitflesh based on if the hit material of the trace is MAT_FLESH.
- Bad field "Damage" in the table used in 'FireBullets' on line shared.lua:91: (setting damage to 0 causes error 'AddMultiDamage: g_MultiDamage.GetDamageForce() == vec3_origin')

[GAMEPLAY]
+ Switched from TraceLine to TraceHull, traces now also clip to entity's bounding boxes and not actual hitboxes, this might be for good as some entities have genuinely retarded hitboxes and collision meshes, who knows.

[TODO]
+ Fix blood not appearing (caused by Damage being set to 0 in 'FireBullets' on line shared.lua:91)